### PR TITLE
Failing unit test for the string conversion issue

### DIFF
--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -38,6 +38,7 @@ set (UNITTEST_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_voxelalgorithms.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_voxelmanipulator.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_gettext.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test_wide_string_conversion.cpp
 	PARENT_SCOPE)
 
 set (UNITTEST_CLIENT_SRCS

--- a/src/unittest/test_wide_string_conversion.cpp
+++ b/src/unittest/test_wide_string_conversion.cpp
@@ -1,0 +1,68 @@
+/*
+Minetest
+Copyright (C) 2023 Gregor Parzefall
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "test.h"
+
+#include "util/string.h"
+#include "irrString.h"
+
+class TestWideStringConversion : public TestBase {
+public:
+	TestWideStringConversion() { TestManager::registerTestModule(this); }
+	const char *getName() { return "TestWideStringConversion"; }
+
+	void runTests(IGameDef *gamedef);
+
+	void testWideStringConversion();
+};
+
+static TestWideStringConversion g_test_instance;
+
+void TestWideStringConversion::runTests(IGameDef *gamedef)
+{
+	TEST(testWideStringConversion);
+}
+
+void TestWideStringConversion::testWideStringConversion()
+{
+	{
+		std::wstring std_wide = utf8_to_wide("🪴äöüß🪴");
+		std::string std_utf8 = wide_to_utf8(std_wide);
+		UASSERT(std_utf8 == "🪴äöüß🪴");
+	}
+	{
+		core::stringw irr_wide;
+		core::multibyteToWString(irr_wide, "🪴äöüß🪴");
+		core::stringc irr_utf8;
+		core::wStringToMultibyte(irr_utf8, irr_wide);
+		UASSERT(irr_utf8 == "🪴äöüß🪴");
+	}
+	{
+		core::stringw irr_wide;
+		core::multibyteToWString(irr_wide, "🪴äöüß🪴");
+		std::string std_utf8 = wide_to_utf8(irr_wide.c_str());
+		UASSERT(std_utf8 == "🪴äöüß🪴");
+	}
+	{
+		std::wstring std_wide = utf8_to_wide("🪴äöüß🪴");
+		core::stringc irr_utf8;
+		core::wStringToMultibyte(irr_utf8, std_wide.c_str());
+		UASSERT(irr_utf8 == "🪴äöüß🪴");
+	}
+}


### PR DESCRIPTION
This dummy PR adds a unit test for the string conversion issue. You should see Windows CI fail.

EDIT: Actually, the Windows CI doesn't even run the unittests. And there are already multiple unittests that fail on Windows.